### PR TITLE
Allow additional changes via workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,15 @@ action "PHPStan" {
 You might want to add extra plugins to phpstan to be more strict. To install them define
 `COMPOSER_PACKAGES` as environment variable in your workflow.
 
+**Please note that installing plugins using the environment variable has impact on the execution time. To speed up your workflow push a prepared image to a docker repository**
+
 ## Additional Alpine packages
 The docker image contains a minimal set of installed php packages. For some projects you
 might want to add more php extensions. Define `PHP_EXTENSIONS` as environment variable in
 your workflow to do so.
+
+**Please note that installing packages using the environment variable has impact on the execution time. To speed up your workflow push a prepared image to a docker repository**
+
 
 ## Docker
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,15 @@ action "PHPStan" {
 
 **You can copy/paste the .github folder (under examples/) to your project and thats all!**
 
+## PHPStan plugins
+You might want to add extra plugins to phpstan to be more strict. To install them define
+`COMPOSER_PACKAGES` as environment variable in your workflow.
+
+## Additional Alpine packages
+The docker image contains a minimal set of installed php packages. For some projects you
+might want to add more php extensions. Define `PHP_EXTENSIONS` as environment variable in
+your workflow to do so.
+
 ## Docker
 
 A Docker-Image is built automatically and located here:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,3 +1,15 @@
 #!/bin/sh -l
 
+=======
+if [[ ! -z "$PHP_EXTENSIONS" ]]; then
+  echo "installing $PHP_EXTENSIONS"
+  apk add -q --no-cache $PHP_EXTENSIONS;
+  rm -rf /var/cache/apk/*;
+fi
+
+if [[ ! -z "$COMPOSER_PACKAGES" ]]; then
+   echo "installing $COMPOSER_PACKAGES"
+   composer global require --quiet $COMPOSER_PACKAGES;
+fi
+
 sh -c "composer install --no-scripts --no-progress && /composer/vendor/bin/phpstan $*"


### PR DESCRIPTION
For many projects you will need extra php extensions and phpstan plugins. The changes in this PR allow you to define 2 environment variables to customize the image without any need to publish your own image and maintain your own custom actions.

I think it is needless to have multiple forks of this very nice small setup for a working github action. The suggested changes are used in https://github.com/phpDocumentor/phpDocumentor2/pull/2049. 