### PR TITLE
Silence composer task

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,3 +1,3 @@
 #!/bin/sh -l
 
-sh -c "composer install --no-scripts --no-progress && /composer/vendor/bin/phpstan $*"
+sh -c "composer install --no-scripts --no-progress --quiet && /composer/vendor/bin/phpstan $*"


### PR DESCRIPTION
In most cases the output of composer is irrelevant for the phpstan execution and pollutes the output. 