### PR TITLE
Allow installation of dev dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,24 @@ jobs:
 +        args: analyse src/ --level=5
 ```
 
+_to install dev dependencies:_
+```diff
+on: [push, pull_request]
+name: Test
+jobs:
+  phpstan:
+    name: PHPStan
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: PHPStan
+      uses: docker://oskarstark/phpstan-ga
++     env:
++       REQUIRE_DEV: true
+      with:
+        args: analyse src/
+```
+
 _to use a phpstan.neon.dist configuration file:_
 
 just drop the `phpstan.neon.dist` in your repository root and it will be taken into account.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,3 +1,8 @@
 #!/bin/sh -l
 
-sh -c "composer install --no-scripts --no-progress --quiet --no-dev && /composer/vendor/bin/phpstan $*"
+NO_DEV="--no-dev"
+if [ "$REQUIRE_DEV" = "true" ]; then
+    NO_DEV=""
+fi
+
+sh -c "composer install --no-scripts --no-progress --quiet $NO_DEV && /composer/vendor/bin/phpstan $*"


### PR DESCRIPTION
This might help resolve #21 if `--no-dev` is preferable by default _(relates to #20)_

### Added
- Allowing installation of dev dependencies using `REQUIRE_DEV=true` environment variable.
  > Defaults to `--no-dev`

It might be neater using arguments, but this approach would be less disruptive to current users