### PR TITLE
fix: phpstan version selection

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,12 @@ description: 'Use PHPStan via GithubAction.'
 
 name: 'OSKAR-phpstan'
 
+inputs:
+  version:
+    description: phpstan version, defaults to latest
+    required: false
+    default: latest
+
 runs:
     using: 'docker'
-    image: 'docker://oskarstark/phpstan-ga'
+    image: 'docker://oskarstark/phpstan-ga:${{ inputs.version }}'


### PR DESCRIPTION
Fixes #28 

This is not BC BREAK because today even if you believe using a tagged version you always run the latest version anyway.

Maybe this PR should be completed by some documentation and disclaimer about the change though, as to me from now the action should be tagged @v1 and have independant tagging lifecycle from phpstan tagging.