### PR TITLE
Build docker image periodically

### DIFF
--- a/.github/workflows/watch.yml
+++ b/.github/workflows/watch.yml
@@ -1,4 +1,4 @@
-name: Watch for changes
+name: Watch
 
 on:
   schedule:
@@ -6,30 +6,25 @@ on:
 
 jobs:
   docker:
-    name: Update docker image with latest version
+    name: Push docker image
     runs-on: ubuntu-latest
 
     steps:
-      - name: Set up PHP
-        uses: shivammathur/setup-php@2.1.2
-        with:
-          php-version: 7.4
-          coverage: none
-
       - name: Checkout code
         uses: actions/checkout@v2
         with:
           ref: master
-          token: ${{ secrets.BOT_GITHUB_TOKEN }}
 
-      - name: Fetch last version
+      - name: Update Dockerfile with latest version
         id: fetch_version
         run: |
           last=$(curl -s https://packagist.org/packages/phpstan/phpstan.json|jq '[.package.versions[]|select(.version|test("^\\d+\\.\\d+\\.\\d+$"))|.version]|max_by(.|[splits("[.]")]|map(tonumber))')
+          last=$(echo $last | tr -d '"')
           echo "Last PHPStan version is $last"
           echo ::set-output name=last::$last
 
-          sed -i -re "s/require phpstan\/phpstan [^\\]/require phpstan\/phpstan $last" Dockerfile
+          sed -i -re "s/require phpstan\/phpstan [^\\]+/require phpstan\/phpstan $last /" Dockerfile
+          cat Dockerfile
 
       - name: Docker login
         run: echo '${{ secrets.DOCKER_PASSWORD }}' | docker login --username ${{ secrets.DOCKER_USERNAME }} --password-stdin

--- a/.github/workflows/watch.yml
+++ b/.github/workflows/watch.yml
@@ -1,0 +1,41 @@
+name: Watch for changes
+
+on:
+  schedule:
+    - cron: '0 2,8,14,20 * * *'
+
+jobs:
+  docker:
+    name: Update docker image with latest version
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set up PHP
+        uses: shivammathur/setup-php@2.1.2
+        with:
+          php-version: 7.4
+          coverage: none
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          ref: master
+          token: ${{ secrets.BOT_GITHUB_TOKEN }}
+
+      - name: Fetch last version
+        id: fetch_version
+        run: |
+          last=$(curl -s https://packagist.org/packages/phpstan/phpstan.json|jq '[.package.versions[]|select(.version|test("^\\d+\\.\\d+\\.\\d+$"))|.version]|max_by(.|[splits("[.]")]|map(tonumber))')
+          echo "Last PHPStan version is $last"
+          echo ::set-output name=last::$last
+
+          sed -i -re "s/require phpstan\/phpstan [^\\]/require phpstan\/phpstan $last" Dockerfile
+
+      - name: Docker login
+        run: echo '${{ secrets.DOCKER_PASSWORD }}' | docker login --username ${{ secrets.DOCKER_USERNAME }} --password-stdin
+
+      - name: Build images
+        run: docker build -t oskarstark/phpstan-ga:${{ steps.fetch_version.outputs.last }} .
+
+      - name: Publish
+        run: docker push oskarstark/phpstan-ga:${{ steps.fetch_version.outputs.last }}


### PR DESCRIPTION
This will fix #31 

This will run every 6 hours. It will tag add push a docker image. This needs us generating an application password. 

One can of course expand this later to automatically tag the repo too. 