### PR TITLE
Enhancement: Automatically get latest PHPStan version and commit to Dockerfile

### DIFF
--- a/.github/workflows/watch.yml
+++ b/.github/workflows/watch.yml
@@ -1,0 +1,39 @@
+name: Watch
+
+on:
+    workflow_dispatch:
+    schedule:
+        - cron: '30 */4 * * *'
+
+jobs:
+    update-version:
+        name: Automatically get latest PHPStan version and commit
+
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: "Checkout code"
+              uses: actions/checkout@v2
+              with:
+                  ref: master
+
+            - name: "Update Dockerfile and action.yml"
+              id: fetch_version
+              run: |
+                  latest=$(curl -s https://packagist.org/packages/phpstan/phpstan.json|jq '[.package.versions[]|select(.version|test("^\\d+\\.\\d+\\.\\d+$"))|.version]|max_by(.|[splits("[.]")]|map(tonumber))')
+                  latest=$(echo $latest | tr -d '"')
+                  echo "Latest PHPStan version is $latest"
+                  echo ::set-output name=latest::$latest
+                  sed -i -re "s/ENV VERSION=.*/ENV VERSION=$latest/" Dockerfile
+                  cat Dockerfile
+                  sed -i -re "s/phpstan-ga:[0-9.]+/phpstan-ga:$latest/" action.yml
+                  cat action.yml
+
+            - name: "Commit updated files"
+              uses: stefanzweifel/git-auto-commit-action@v4
+              with:
+                  commit_author: "Oskar Stark <oskarstark@googlemail.com>"
+                  commit_message: "Enhancement: Upgrade to PHPStan ${{ steps.fetch_version.outputs.latest }}"
+                  commit_user_email: "oskarstark@googlemail.com"
+                  commit_user_name: "Oskar Stark"
+                  tagging_message: ${{ steps.fetch_version.outputs.latest }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,9 @@ ENV COMPOSER_HOME=/composer
 
 RUN echo "memory_limit=-1" > $PHP_INI_DIR/conf.d/memory-limit.ini
 
-RUN composer global require phpstan/phpstan 0.12.43 \
+ENV VERSION=0.12.43
+
+RUN composer global require phpstan/phpstan $VERSION \
     && composer global require phpstan/extension-installer \
     && composer global require phpstan/phpstan-doctrine \
     && composer global require phpstan/phpstan-phpunit \


### PR DESCRIPTION
Most of this change is based on the work of @Nyholm. Thank you 🙏 

I added `workflow_dispatch:` event to be able to execute this action any given time by a manual click.
![CleanShot 2020-09-25 at 09 44 10](https://user-images.githubusercontent.com/995707/94240544-b8510380-ff13-11ea-9cb5-e914dff16657.png)

If this works, I will use it for https://github.com/OskarStark/php-cs-fixer-ga too.

### Result
![CleanShot 2020-09-25 at 09 37 54](https://user-images.githubusercontent.com/995707/94239932-cfdbbc80-ff12-11ea-8e33-f1186765ed0d.png)

### Note
The only thing I could only test while merging it to `master` is the tagging 🤞 

**EDIT**
The tag was created 🥳 
![CleanShot 2020-09-25 at 09 45 37](https://user-images.githubusercontent.com/995707/94240709-f5b59100-ff13-11ea-88bb-09e4e44f05ff.png)