### PR TITLE
update to php 8.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.0-alpine
+FROM php:8.1-alpine
 
 LABEL "com.github.actions.name"="OSKAR-phpstan"
 LABEL "com.github.actions.description"="phpstan"


### PR DESCRIPTION
hi, we use this action in https://github.com/php-http/react-adapter/ . in https://github.com/php-http/react-adapter/pull/50 we try to switch to the new php 8.1 features and therefore would need to run phpstan with php 8.1 as well. can we upgrade the action to run on php 8.1?

