### PR TITLE
Use binary-only images for installing Composer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ LABEL "repository"="http://github.com/oskarstark/phpstan-ga"
 LABEL "homepage"="http://github.com/actions"
 LABEL "maintainer"="Oskar Stark <oskarstark@googlemail.com>"
 
-COPY --from=composer:2.3.10 /usr/bin/composer /usr/local/bin/composer
+COPY --from=composer:2.3.10-bin /composer /usr/local/bin/composer
 
 RUN mkdir /composer
 ENV COMPOSER_HOME=/composer


### PR DESCRIPTION
See: https://blog.codito.dev/2022/11/composer-binary-only-docker-images/